### PR TITLE
fix usage of deprecated assertRaisesRegex

### DIFF
--- a/python/pydiffx/tests/testcases.py
+++ b/python/pydiffx/tests/testcases.py
@@ -65,5 +65,5 @@ class TestCase(unittest.TestCase):
 
     @contextmanager
     def assertRaisesMessage(self, exception, message):
-        with self.assertRaisesRegexp(exception, re.escape(message)):
+        with self.assertRaises(exception, msg=message):
             yield


### PR DESCRIPTION
Tested on python 3.10, 3.11 & 3.11
Based on [docs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaises), it should be supported on all relevant python 3 versions.

Resolves: https://github.com/beanbaginc/diffx/issues/4